### PR TITLE
add array constructors for non-hcc compilers

### DIFF
--- a/unsupported/Eigen/CXX11/src/util/EmulateArray.h
+++ b/unsupported/Eigen/CXX11/src/util/EmulateArray.h
@@ -169,6 +169,10 @@ template <typename T> class array<T, 1> {
   void __cxxamp_serialize(Kalmar::Serialize &s) const {
     s.Append(sizeof(T), &values[0]);
   }
+#else
+  array(T v0) {
+    values[0] = v0;
+  }
 #endif
 };
 
@@ -217,6 +221,11 @@ template <typename T> class array<T, 2> {
   void __cxxamp_serialize(Kalmar::Serialize &s) const {
     s.Append(sizeof(T), &values[0]);
     s.Append(sizeof(T), &values[1]);
+  }
+#else
+  array(T v0, T v1) {
+    values[0] = v0;
+    values[1] = v1;
   }
 #endif
 };
@@ -268,6 +277,12 @@ template <typename T> class array<T, 3> {
     s.Append(sizeof(T), &values[0]);
     s.Append(sizeof(T), &values[1]);
     s.Append(sizeof(T), &values[2]);
+  }
+#else
+  array(T v0, T v1, T v2) {
+    values[0] = v0;
+    values[1] = v1;
+    values[2] = v2;
   }
 #endif
 };
@@ -321,6 +336,13 @@ template <typename T> class array<T, 4> {
     s.Append(sizeof(T), &values[1]);
     s.Append(sizeof(T), &values[2]);
     s.Append(sizeof(T), &values[3]);
+  }
+#else
+  array(T v0, T v1, T v2, T v3) {
+    values[0] = v0;
+    values[1] = v1;
+    values[2] = v2;
+    values[3] = v3;
   }
 #endif
 };
@@ -376,6 +398,14 @@ template <typename T> class array<T, 5> {
     s.Append(sizeof(T), &values[2]);
     s.Append(sizeof(T), &values[3]);
     s.Append(sizeof(T), &values[4]);
+  }
+#else
+  array(T v0, T v1, T v2, T v3, T v4) {
+    values[0] = v0;
+    values[1] = v1;
+    values[2] = v2;
+    values[3] = v3;
+    values[4] = v4;
   }
 #endif
 };


### PR DESCRIPTION
add missing constructors when compiling with non-hcc compiler like g++