### PR TITLE
Add additional dtors used by GPU ops

### DIFF
--- a/unsupported/Eigen/CXX11/src/Tensor/TensorExpr.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorExpr.h
@@ -62,6 +62,8 @@ class TensorCwiseNullaryOp : public TensorBase<TensorCwiseNullaryOp<NullaryOp, X
     EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE TensorCwiseNullaryOp(const XprType& xpr, const NullaryOp& func = NullaryOp())
         : m_xpr(xpr), m_functor(func) {}
 
+    EIGEN_DEVICE_FUNC ~TensorCwiseNullaryOp() {}
+
     EIGEN_DEVICE_FUNC
     const typename internal::remove_all<typename XprType::Nested>::type&
     nestedExpression() const { return m_xpr; }
@@ -122,6 +124,8 @@ class TensorCwiseUnaryOp : public TensorBase<TensorCwiseUnaryOp<UnaryOp, XprType
 
     EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE TensorCwiseUnaryOp(const XprType& xpr, const UnaryOp& func = UnaryOp())
       : m_xpr(xpr), m_functor(func) {}
+
+    EIGEN_DEVICE_FUNC ~TensorCwiseUnaryOp() {}
 
     EIGEN_DEVICE_FUNC
     const UnaryOp& functor() const { return m_functor; }
@@ -199,6 +203,8 @@ class TensorCwiseBinaryOp : public TensorBase<TensorCwiseBinaryOp<BinaryOp, LhsX
     EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE TensorCwiseBinaryOp(const LhsXprType& lhs, const RhsXprType& rhs, const BinaryOp& func = BinaryOp())
         : m_lhs_xpr(lhs), m_rhs_xpr(rhs), m_functor(func) {}
 
+    EIGEN_DEVICE_FUNC ~TensorCwiseBinaryOp() {}
+
     EIGEN_DEVICE_FUNC
     const BinaryOp& functor() const { return m_functor; }
 
@@ -273,6 +279,8 @@ class TensorCwiseTernaryOp : public TensorBase<TensorCwiseTernaryOp<TernaryOp, A
 
     EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE TensorCwiseTernaryOp(const Arg1XprType& arg1, const Arg2XprType& arg2, const Arg3XprType& arg3, const TernaryOp& func = TernaryOp())
         : m_arg1_xpr(arg1), m_arg2_xpr(arg2), m_arg3_xpr(arg3), m_functor(func) {}
+
+    EIGEN_DEVICE_FUNC ~TensorCwiseTernaryOp() {}
 
     EIGEN_DEVICE_FUNC
     const TernaryOp& functor() const { return m_functor; }
@@ -349,6 +357,8 @@ class TensorSelectOp : public TensorBase<TensorSelectOp<IfXprType, ThenXprType, 
                    const ElseXprType& a_else)
       : m_condition(a_condition), m_then(a_then), m_else(a_else)
     { }
+
+    EIGEN_DEVICE_FUNC ~TensorSelectOp() {}
 
     EIGEN_DEVICE_FUNC
     const IfXprType& ifExpression() const { return m_condition; }

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorReduction.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorReduction.h
@@ -364,6 +364,8 @@ class TensorReductionOp : public TensorBase<TensorReductionOp<Op, Dims, XprType,
     TensorReductionOp(const XprType& expr, const Dims& dims, const Op& reducer) : m_expr(expr), m_dims(dims), m_reducer(reducer)
     { }
 
+    EIGEN_DEVICE_FUNC ~TensorReductionOp() {}
+
     EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
     const XprType& expression() const { return m_expr; }
     EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorShuffling.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorShuffling.h
@@ -63,6 +63,8 @@ class TensorShufflingOp : public TensorBase<TensorShufflingOp<Shuffle, XprType> 
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE TensorShufflingOp(const XprType& expr, const Shuffle& shuffle)
       : m_xpr(expr), m_shuffle(shuffle) {}
 
+  EIGEN_DEVICE_FUNC ~TensorShufflingOp() {}
+
     EIGEN_DEVICE_FUNC
     const Shuffle& shufflePermutation() const { return m_shuffle; }
 


### PR DESCRIPTION
The PR is made to help fix compile-time failures among several TensorFlow directed tests when compiled with HCC. It is required to explicitly define dtors as of now.