### PR TITLE
Custom serializers / deserializers for hipeigen

### DIFF
--- a/unsupported/Eigen/CXX11/src/Tensor/TensorExecutor.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorExecutor.h
@@ -232,13 +232,13 @@ struct EigenMetaKernelEval<Evaluator, Index, true> {
 };
 
 // FIXME - remove this once launch_bounds=1024 is working correctly.
-#define MAX_BLOCK_SIZE 256
+#define MAX_BLOCK_SIZE 512
 
 template <typename Evaluator, typename Index>
-__global__ void
 //FIXME: why add 1 here?
 //__launch_bounds__(1024, 1)
 __launch_bounds__(MAX_BLOCK_SIZE, 1)
+__global__ void
 EigenMetaKernel( Evaluator eval, Index size){
   const Index first_index = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
   const Index step_size = hipBlockDim_x * hipGridDim_x;

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorIntDiv.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorIntDiv.h
@@ -14,6 +14,12 @@
 #include "Eigen/src/Core/arch/HIP/hcc/intrinsics.h"
 #endif
 
+// Custom serializers / deserializers for Eigen::array
+// with Eigen::internal::TensorIntDivisor as elements
+#ifdef __HCC__
+#include "../util/EmulateArray.h"
+#endif
+
 namespace Eigen {
 
 /** \internal
@@ -189,7 +195,9 @@ struct TensorIntDivisor {
     return (t1 + t) >> shift2;
   }
 
- private:
+
+  // In order to allow custom serializers push them to kernels on the host side,
+  // change these member variables be public.
   typedef typename DividerTraits<T>::type UnsignedType;
   UnsignedType multiplier;
   int32_t shift1;
@@ -272,5 +280,908 @@ static EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE T operator / (const T& numerator, c
 
 } // end namespace internal
 } // end namespace Eigen
+
+
+// Custom serializers / deserializers for Eigen::array
+// with Eigen::internal::TensorIntDivisor as elements
+#ifdef __HCC__
+namespace Eigen {
+
+// Specialize array for size 1 and T = Eigen::internal::TensorIntDivisor<long, false>
+template <>
+class array<Eigen::internal::TensorIntDivisor<long, false>, 1> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<long, false>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<long, false>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<long, false>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<long, false>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<long, false>& back() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<long, false>& back() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 1; }
+
+  Eigen::internal::TensorIntDivisor<long, false> values[1];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::internal::TensorIntDivisor<long, false> > l) {
+    eigen_assert(l.size() == 1);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(unsigned long divider) [[cpu]][[hc]] {
+    values[0] = Eigen::internal::TensorIntDivisor<long, false>(divider);
+  }
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    s.Append(sizeof(unsigned long), &values[0].multiplier);
+  }
+};
+
+// Specialize array for size 1 and T = Eigen::internal::TensorIntDivisor<int, false>
+template <>
+class array<Eigen::internal::TensorIntDivisor<int, false>, 1> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<int, false>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<int, false>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<int, false>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<int, false>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<int, false>& back() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<int, false>& back() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 1; }
+
+  Eigen::internal::TensorIntDivisor<int, false> values[1];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::internal::TensorIntDivisor<int, false> > l) {
+    eigen_assert(l.size() == 1);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(unsigned int divider) [[cpu]][[hc]] {
+    values[0] = Eigen::internal::TensorIntDivisor<int, false>(divider);
+  }
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    s.Append(sizeof(unsigned int), &values[0].multiplier);
+  }
+};
+
+// Specialize array for size 2 and T = Eigen::internal::TensorIntDivisor<long, false>
+template <>
+class array<Eigen::internal::TensorIntDivisor<long, false>, 2> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<long, false>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<long, false>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<long, false>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<long, false>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<long, false>& back() { return values[1]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<long, false>& back() const { return values[1]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 2; }
+
+  Eigen::internal::TensorIntDivisor<long, false> values[2];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::internal::TensorIntDivisor<long, false>> l) {
+    eigen_assert(l.size() == 2);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(unsigned long v0, unsigned long v1) [[cpu]][[hc]] {
+    values[0] = Eigen::internal::TensorIntDivisor<long, false>(v0);
+    values[1] = Eigen::internal::TensorIntDivisor<long, false>(v1);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    s.Append(sizeof(unsigned long), &values[0].multiplier);
+    s.Append(sizeof(unsigned long), &values[1].multiplier);
+  }
+};
+
+// Specialize array for size 2 and T = Eigen::internal::TensorIntDivisor<int, false>
+template <>
+class array<Eigen::internal::TensorIntDivisor<int, false>, 2> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<int, false>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<int, false>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<int, false>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<int, false>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<int, false>& back() { return values[1]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<int, false>& back() const { return values[1]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 2; }
+
+  Eigen::internal::TensorIntDivisor<int, false> values[2];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::internal::TensorIntDivisor<int, false>> l) {
+    eigen_assert(l.size() == 2);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(unsigned int v0, unsigned int v1) [[cpu]][[hc]] {
+    values[0] = Eigen::internal::TensorIntDivisor<int, false>(v0);
+    values[1] = Eigen::internal::TensorIntDivisor<int, false>(v1);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    s.Append(sizeof(unsigned int), &values[0].multiplier);
+    s.Append(sizeof(unsigned int), &values[1].multiplier);
+  }
+};
+
+// Specialize array for size 3 and T = Eigen::internal::TensorIntDivisor<long, false>
+template <>
+class array<Eigen::internal::TensorIntDivisor<long, false>, 3> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<long, false>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<long, false>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<long, false>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<long, false>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<long, false>& back() { return values[2]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<long, false>& back() const { return values[2]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 3; }
+
+  Eigen::internal::TensorIntDivisor<long, false> values[3];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::internal::TensorIntDivisor<long, false> > l) {
+    eigen_assert(l.size() == 3);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(unsigned long v0, unsigned long v1, unsigned long v2) [[cpu]][[hc]] {
+    values[0] = Eigen::internal::TensorIntDivisor<long, false>(v0);
+    values[1] = Eigen::internal::TensorIntDivisor<long, false>(v1);
+    values[2] = Eigen::internal::TensorIntDivisor<long, false>(v2);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    s.Append(sizeof(unsigned long), &values[0].multiplier);
+    s.Append(sizeof(unsigned long), &values[1].multiplier);
+    s.Append(sizeof(unsigned long), &values[2].multiplier);
+  }
+};
+
+// Specialize array for size 3 and T = Eigen::internal::TensorIntDivisor<int, false>
+template <>
+class array<Eigen::internal::TensorIntDivisor<int, false>, 3> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<int, false>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<int, false>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<int, false>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<int, false>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<int, false>& back() { return values[2]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<int, false>& back() const { return values[2]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 3; }
+
+  Eigen::internal::TensorIntDivisor<int, false> values[3];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::internal::TensorIntDivisor<int, false> > l) {
+    eigen_assert(l.size() == 3);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(unsigned int v0, unsigned int v1, unsigned int v2) [[cpu]][[hc]] {
+    values[0] = Eigen::internal::TensorIntDivisor<int, false>(v0);
+    values[1] = Eigen::internal::TensorIntDivisor<int, false>(v1);
+    values[2] = Eigen::internal::TensorIntDivisor<int, false>(v2);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    s.Append(sizeof(unsigned int), &values[0].multiplier);
+    s.Append(sizeof(unsigned int), &values[1].multiplier);
+    s.Append(sizeof(unsigned int), &values[2].multiplier);
+  }
+};
+
+// Specialize array for size 4 and T = Eigen::internal::TensorIntDivisor<long, false>
+template <>
+class array<Eigen::internal::TensorIntDivisor<long, false>, 4> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<long, false>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<long, false>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<long, false>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<long, false>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<long, false>& back() { return values[3]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<long, false>& back() const { return values[3]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 4; }
+
+  Eigen::internal::TensorIntDivisor<long, false> values[4];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::internal::TensorIntDivisor<long, false> > l) {
+    eigen_assert(l.size() == 4);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(unsigned long v0, unsigned long v1, unsigned long v2, unsigned long v3) [[cpu]][[hc]] {
+    values[0] = Eigen::internal::TensorIntDivisor<long, false>(v0);
+    values[1] = Eigen::internal::TensorIntDivisor<long, false>(v1);
+    values[2] = Eigen::internal::TensorIntDivisor<long, false>(v2);
+    values[3] = Eigen::internal::TensorIntDivisor<long, false>(v3);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    s.Append(sizeof(unsigned long), &values[0].multiplier);
+    s.Append(sizeof(unsigned long), &values[1].multiplier);
+    s.Append(sizeof(unsigned long), &values[2].multiplier);
+    s.Append(sizeof(unsigned long), &values[3].multiplier);
+  }
+};
+
+// Specialize array for size 4 and T = Eigen::internal::TensorIntDivisor<int, false>
+template <>
+class array<Eigen::internal::TensorIntDivisor<int, false>, 4> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<int, false>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<int, false>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<int, false>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<int, false>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<int, false>& back() { return values[3]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<int, false>& back() const { return values[3]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 4; }
+
+  Eigen::internal::TensorIntDivisor<int, false> values[4];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::internal::TensorIntDivisor<int, false> > l) {
+    eigen_assert(l.size() == 4);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(unsigned int v0, unsigned int v1, unsigned int v2, unsigned int v3) [[cpu]][[hc]] {
+    values[0] = Eigen::internal::TensorIntDivisor<int, false>(v0);
+    values[1] = Eigen::internal::TensorIntDivisor<int, false>(v1);
+    values[2] = Eigen::internal::TensorIntDivisor<int, false>(v2);
+    values[3] = Eigen::internal::TensorIntDivisor<int, false>(v3);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    s.Append(sizeof(unsigned int), &values[0].multiplier);
+    s.Append(sizeof(unsigned int), &values[1].multiplier);
+    s.Append(sizeof(unsigned int), &values[2].multiplier);
+    s.Append(sizeof(unsigned int), &values[3].multiplier);
+  }
+};
+
+// Specialize array for size 5 and T = Eigen::internal::TensorIntDivisor<long, false>
+template <>
+class array<Eigen::internal::TensorIntDivisor<long, false>, 5> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<long, false>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<long, false>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<long, false>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<long, false>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<long, false>& back() { return values[4]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<long, false>& back() const { return values[4]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 5; }
+
+  Eigen::internal::TensorIntDivisor<long, false> values[5];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::internal::TensorIntDivisor<long, false>> l) {
+    eigen_assert(l.size() == 5);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(unsigned long v0, unsigned long v1, unsigned long v2, unsigned long v3, unsigned long v4) [[cpu]][[hc]] {
+    values[0] = Eigen::internal::TensorIntDivisor<long, false>(v0);
+    values[1] = Eigen::internal::TensorIntDivisor<long, false>(v1);
+    values[2] = Eigen::internal::TensorIntDivisor<long, false>(v2);
+    values[3] = Eigen::internal::TensorIntDivisor<long, false>(v3);
+    values[4] = Eigen::internal::TensorIntDivisor<long, false>(v4);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    s.Append(sizeof(unsigned long), &values[0].multiplier);
+    s.Append(sizeof(unsigned long), &values[1].multiplier);
+    s.Append(sizeof(unsigned long), &values[2].multiplier);
+    s.Append(sizeof(unsigned long), &values[3].multiplier);
+    s.Append(sizeof(unsigned long), &values[4].multiplier);
+  }
+};
+
+// Specialize array for size 5 and T = Eigen::internal::TensorIntDivisor<int, false>
+template <>
+class array<Eigen::internal::TensorIntDivisor<int, false>, 5> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<int, false>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<int, false>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<int, false>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<int, false>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<int, false>& back() { return values[4]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<int, false>& back() const { return values[4]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 5; }
+
+  Eigen::internal::TensorIntDivisor<int, false> values[5];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::internal::TensorIntDivisor<int, false>> l) {
+    eigen_assert(l.size() == 5);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(unsigned int v0, unsigned int v1, unsigned int v2, unsigned int v3, unsigned int v4) [[cpu]][[hc]] {
+    values[0] = Eigen::internal::TensorIntDivisor<int, false>(v0);
+    values[1] = Eigen::internal::TensorIntDivisor<int, false>(v1);
+    values[2] = Eigen::internal::TensorIntDivisor<int, false>(v2);
+    values[3] = Eigen::internal::TensorIntDivisor<int, false>(v3);
+    values[4] = Eigen::internal::TensorIntDivisor<int, false>(v4);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    s.Append(sizeof(unsigned int), &values[0].multiplier);
+    s.Append(sizeof(unsigned int), &values[1].multiplier);
+    s.Append(sizeof(unsigned int), &values[2].multiplier);
+    s.Append(sizeof(unsigned int), &values[3].multiplier);
+    s.Append(sizeof(unsigned int), &values[4].multiplier);
+  }
+};
+
+// Specialize array for size 6 and T = Eigen::internal::TensorIntDivisor<long, false>
+template <>
+class array<Eigen::internal::TensorIntDivisor<long, false>, 6> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<long, false>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<long, false>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<long, false>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<long, false>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<long, false>& back() { return values[5]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<long, false>& back() const { return values[5]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 6; }
+
+  Eigen::internal::TensorIntDivisor<long, false> values[6];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::internal::TensorIntDivisor<long, false>> l) {
+    eigen_assert(l.size() == 6);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(unsigned long v0, unsigned long v1, unsigned long v2, unsigned long v3, unsigned long v4, unsigned long v5) [[cpu]][[hc]] {
+    values[0] = Eigen::internal::TensorIntDivisor<long, false>(v0);
+    values[1] = Eigen::internal::TensorIntDivisor<long, false>(v1);
+    values[2] = Eigen::internal::TensorIntDivisor<long, false>(v2);
+    values[3] = Eigen::internal::TensorIntDivisor<long, false>(v3);
+    values[4] = Eigen::internal::TensorIntDivisor<long, false>(v4);
+    values[5] = Eigen::internal::TensorIntDivisor<long, false>(v5);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    s.Append(sizeof(unsigned long), &values[0].multiplier);
+    s.Append(sizeof(unsigned long), &values[1].multiplier);
+    s.Append(sizeof(unsigned long), &values[2].multiplier);
+    s.Append(sizeof(unsigned long), &values[3].multiplier);
+    s.Append(sizeof(unsigned long), &values[4].multiplier);
+    s.Append(sizeof(unsigned long), &values[5].multiplier);
+  }
+};
+
+// Specialize array for size 6 and T = Eigen::internal::TensorIntDivisor<int, false>
+template <>
+class array<Eigen::internal::TensorIntDivisor<int, false>, 6> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<int, false>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<int, false>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<int, false>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<int, false>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<int, false>& back() { return values[5]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<int, false>& back() const { return values[5]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 6; }
+
+  Eigen::internal::TensorIntDivisor<int, false> values[6];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::internal::TensorIntDivisor<int, false>> l) {
+    eigen_assert(l.size() == 6);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(unsigned int v0, unsigned int v1, unsigned int v2, unsigned int v3, unsigned int v4, unsigned int v5) [[cpu]][[hc]] {
+    values[0] = Eigen::internal::TensorIntDivisor<int, false>(v0);
+    values[1] = Eigen::internal::TensorIntDivisor<int, false>(v1);
+    values[2] = Eigen::internal::TensorIntDivisor<int, false>(v2);
+    values[3] = Eigen::internal::TensorIntDivisor<int, false>(v3);
+    values[4] = Eigen::internal::TensorIntDivisor<int, false>(v4);
+    values[5] = Eigen::internal::TensorIntDivisor<int, false>(v5);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    s.Append(sizeof(unsigned int), &values[0].multiplier);
+    s.Append(sizeof(unsigned int), &values[1].multiplier);
+    s.Append(sizeof(unsigned int), &values[2].multiplier);
+    s.Append(sizeof(unsigned int), &values[3].multiplier);
+    s.Append(sizeof(unsigned int), &values[4].multiplier);
+    s.Append(sizeof(unsigned int), &values[5].multiplier);
+  }
+};
+
+// Specialize array for size 7 and T = Eigen::internal::TensorIntDivisor<long, false>
+template <>
+class array<Eigen::internal::TensorIntDivisor<long, false>, 7> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<long, false>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<long, false>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<long, false>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<long, false>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<long, false>& back() { return values[6]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<long, false>& back() const { return values[6]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 7; }
+
+  Eigen::internal::TensorIntDivisor<long, false> values[7];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::internal::TensorIntDivisor<long, false>> l) {
+    eigen_assert(l.size() == 7);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(unsigned long v0, unsigned long v1, unsigned long v2, unsigned long v3, unsigned long v4, unsigned long v5, unsigned long v6) [[cpu]][[hc]] {
+    values[0] = Eigen::internal::TensorIntDivisor<long, false>(v0);
+    values[1] = Eigen::internal::TensorIntDivisor<long, false>(v1);
+    values[2] = Eigen::internal::TensorIntDivisor<long, false>(v2);
+    values[3] = Eigen::internal::TensorIntDivisor<long, false>(v3);
+    values[4] = Eigen::internal::TensorIntDivisor<long, false>(v4);
+    values[5] = Eigen::internal::TensorIntDivisor<long, false>(v5);
+    values[6] = Eigen::internal::TensorIntDivisor<long, false>(v6);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    s.Append(sizeof(unsigned long), &values[0].multiplier);
+    s.Append(sizeof(unsigned long), &values[1].multiplier);
+    s.Append(sizeof(unsigned long), &values[2].multiplier);
+    s.Append(sizeof(unsigned long), &values[3].multiplier);
+    s.Append(sizeof(unsigned long), &values[4].multiplier);
+    s.Append(sizeof(unsigned long), &values[5].multiplier);
+    s.Append(sizeof(unsigned long), &values[6].multiplier);
+  }
+};
+
+// Specialize array for size 7 and T = Eigen::internal::TensorIntDivisor<int, false>
+template <>
+class array<Eigen::internal::TensorIntDivisor<int, false>, 7> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<int, false>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<int, false>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<int, false>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<int, false>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<int, false>& back() { return values[6]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<int, false>& back() const { return values[6]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 7; }
+
+  Eigen::internal::TensorIntDivisor<int, false> values[7];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::internal::TensorIntDivisor<int, false>> l) {
+    eigen_assert(l.size() == 7);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(unsigned int v0, unsigned int v1, unsigned int v2, unsigned int v3, unsigned int v4, unsigned int v5, unsigned int v6) [[cpu]][[hc]] {
+    values[0] = Eigen::internal::TensorIntDivisor<int, false>(v0);
+    values[1] = Eigen::internal::TensorIntDivisor<int, false>(v1);
+    values[2] = Eigen::internal::TensorIntDivisor<int, false>(v2);
+    values[3] = Eigen::internal::TensorIntDivisor<int, false>(v3);
+    values[4] = Eigen::internal::TensorIntDivisor<int, false>(v4);
+    values[5] = Eigen::internal::TensorIntDivisor<int, false>(v5);
+    values[6] = Eigen::internal::TensorIntDivisor<int, false>(v6);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    s.Append(sizeof(unsigned int), &values[0].multiplier);
+    s.Append(sizeof(unsigned int), &values[1].multiplier);
+    s.Append(sizeof(unsigned int), &values[2].multiplier);
+    s.Append(sizeof(unsigned int), &values[3].multiplier);
+    s.Append(sizeof(unsigned int), &values[4].multiplier);
+    s.Append(sizeof(unsigned int), &values[5].multiplier);
+    s.Append(sizeof(unsigned int), &values[6].multiplier);
+  }
+};
+
+// Specialize array for size 8 and T = Eigen::internal::TensorIntDivisor<long, false>
+template <>
+class array<Eigen::internal::TensorIntDivisor<long, false>, 8> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<long, false>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<long, false>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<long, false>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<long, false>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<long, false>& back() { return values[7]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<long, false>& back() const { return values[7]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 8; }
+
+  Eigen::internal::TensorIntDivisor<long, false> values[8];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::internal::TensorIntDivisor<long, false>> l) {
+    eigen_assert(l.size() == 8);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(unsigned long v0, unsigned long v1, unsigned long v2, unsigned long v3, unsigned long v4, unsigned long v5, unsigned long v6, unsigned long v7) [[cpu]][[hc]] {
+    values[0] = Eigen::internal::TensorIntDivisor<long, false>(v0);
+    values[1] = Eigen::internal::TensorIntDivisor<long, false>(v1);
+    values[2] = Eigen::internal::TensorIntDivisor<long, false>(v2);
+    values[3] = Eigen::internal::TensorIntDivisor<long, false>(v3);
+    values[4] = Eigen::internal::TensorIntDivisor<long, false>(v4);
+    values[5] = Eigen::internal::TensorIntDivisor<long, false>(v5);
+    values[6] = Eigen::internal::TensorIntDivisor<long, false>(v6);
+    values[7] = Eigen::internal::TensorIntDivisor<long, false>(v7);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    s.Append(sizeof(unsigned long), &values[0].multiplier);
+    s.Append(sizeof(unsigned long), &values[1].multiplier);
+    s.Append(sizeof(unsigned long), &values[2].multiplier);
+    s.Append(sizeof(unsigned long), &values[3].multiplier);
+    s.Append(sizeof(unsigned long), &values[4].multiplier);
+    s.Append(sizeof(unsigned long), &values[5].multiplier);
+    s.Append(sizeof(unsigned long), &values[6].multiplier);
+    s.Append(sizeof(unsigned long), &values[7].multiplier);
+  }
+};
+
+// Specialize array for size 8 and T = Eigen::internal::TensorIntDivisor<int, false>
+template <>
+class array<Eigen::internal::TensorIntDivisor<int, false>, 8> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<int, false>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<int, false>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<int, false>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<int, false>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::internal::TensorIntDivisor<int, false>& back() { return values[7]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::internal::TensorIntDivisor<int, false>& back() const { return values[7]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 8; }
+
+  Eigen::internal::TensorIntDivisor<int, false> values[8];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::internal::TensorIntDivisor<int, false>> l) {
+    eigen_assert(l.size() == 8);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(unsigned int v0, unsigned int v1, unsigned int v2, unsigned int v3, unsigned int v4, unsigned int v5, unsigned int v6, unsigned int v7) [[cpu]][[hc]] {
+    values[0] = Eigen::internal::TensorIntDivisor<int, false>(v0);
+    values[1] = Eigen::internal::TensorIntDivisor<int, false>(v1);
+    values[2] = Eigen::internal::TensorIntDivisor<int, false>(v2);
+    values[3] = Eigen::internal::TensorIntDivisor<int, false>(v3);
+    values[4] = Eigen::internal::TensorIntDivisor<int, false>(v4);
+    values[5] = Eigen::internal::TensorIntDivisor<int, false>(v5);
+    values[6] = Eigen::internal::TensorIntDivisor<int, false>(v6);
+    values[7] = Eigen::internal::TensorIntDivisor<int, false>(v7);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    s.Append(sizeof(unsigned int), &values[0].multiplier);
+    s.Append(sizeof(unsigned int), &values[1].multiplier);
+    s.Append(sizeof(unsigned int), &values[2].multiplier);
+    s.Append(sizeof(unsigned int), &values[3].multiplier);
+    s.Append(sizeof(unsigned int), &values[4].multiplier);
+    s.Append(sizeof(unsigned int), &values[5].multiplier);
+    s.Append(sizeof(unsigned int), &values[6].multiplier);
+    s.Append(sizeof(unsigned int), &values[7].multiplier);
+  }
+};
+
+} // end namespace Eigen
+#endif // #ifdef __HCC__
 
 #endif // EIGEN_CXX11_TENSOR_TENSOR_INTDIV_H

--- a/unsupported/Eigen/CXX11/src/Tensor/TensorMeta.h
+++ b/unsupported/Eigen/CXX11/src/Tensor/TensorMeta.h
@@ -10,6 +10,12 @@
 #ifndef EIGEN_CXX11_TENSOR_TENSOR_META_H
 #define EIGEN_CXX11_TENSOR_TENSOR_META_H
 
+// Custom serializers / deserializers for Eigen::array with
+// Eigen::IndexPair<int> or std::pair<int, int> as elements
+#ifdef __HCC__
+#include "../util/EmulateArray.h"
+#endif
+
 namespace Eigen {
 
 template<bool cond> struct Cond {};
@@ -164,6 +170,1676 @@ template <typename Idx> struct IndexPair {
   Idx first;
   Idx second;
 };
+ 
+
+// Custom serializers / deserializers for Eigen::array with
+// Eigen::IndexPair<int> or std::pair<int, int> as elements
+#ifdef __HCC__
+// Specialize array for size 1 and T = Eigen::IndexPair<int>
+template<>
+class array<Eigen::IndexPair<int>, 1> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<int>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<int>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<int>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<int>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<int>& back() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<int>& back() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 1; }
+
+  Eigen::IndexPair<int> values[1];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::IndexPair<int> > l) {
+    eigen_assert(l.size() == 1);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(int first, int second) [[cpu]][[hc]] {
+    values[0] = Eigen::IndexPair<int>(first, second);
+  }
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    s.Append(sizeof(int), &values[0].first);
+    s.Append(sizeof(int), &values[0].second);
+  }
+
+  array(Eigen::IndexPair<int> v0) {
+    values[0].set(v0);
+  }
+};
+
+// Specialize array for size 1 and T = Eigen::IndexPair<long>
+template<>
+class array<Eigen::IndexPair<long>, 1> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<long>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<long>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<long>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<long>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<long>& back() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<long>& back() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 1; }
+
+  Eigen::IndexPair<long> values[1];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::IndexPair<long> > l) {
+    eigen_assert(l.size() == 1);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(long first, long second) [[cpu]][[hc]] {
+    values[0] = Eigen::IndexPair<long>(first, second);
+  }
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    s.Append(sizeof(long), &values[0].first);
+    s.Append(sizeof(long), &values[0].second);
+  }
+
+  array(Eigen::IndexPair<long> v0) {
+    values[0].set(v0);
+  }
+};
+
+// Specialize array for size 1 and T = std::pair<int, int>
+template<>
+class array<std::pair<int, int>, 1> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE std::pair<int, int>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const std::pair<int, int>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE std::pair<int, int> front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const std::pair<int, int>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE std::pair<int, int>& back() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const std::pair<int, int>& back() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 1; }
+
+  std::pair<int, int> values[1];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<std::pair<int, int> > l) {
+    eigen_assert(l.size() == 1);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(int first, int second) [[cpu]][[hc]] {
+    values[0] = std::pair<int, int>(first, second);
+  }
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    s.Append(sizeof(int), &values[0].first);
+    s.Append(sizeof(int), &values[0].second);
+  }
+
+  array(std::pair<int, int> v0) {
+    values[0] = v0;
+  }
+};
+
+// Specialize array for size 2 and T = Eigen::IndexPair<int>
+template <>
+class array<Eigen::IndexPair<int>, 2> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<int>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<int>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<int>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<int>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<int>& back() { return values[1]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<int>& back() const { return values[1]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 2; }
+
+  Eigen::IndexPair<int> values[2];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::IndexPair<int>> l) {
+    eigen_assert(l.size() == 2);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(int v0_first, int v0_second,
+        int v1_first, int v1_second) [[cpu]][[hc]] {
+    values[0] = Eigen::IndexPair<int>(v0_first, v0_second);
+    values[1] = Eigen::IndexPair<int>(v1_first, v1_second);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    s.Append(sizeof(int), &values[0].first);
+    s.Append(sizeof(int), &values[0].second);
+    s.Append(sizeof(int), &values[1].first);
+    s.Append(sizeof(int), &values[1].second);
+  }
+
+  array(Eigen::IndexPair<int> v0,
+        Eigen::IndexPair<int> v1) {
+    values[0].set(v0);
+    values[1].set(v1);
+  }
+};
+
+// Specialize array for size 2 and T = Eigen::IndexPair<long>
+template <>
+class array<Eigen::IndexPair<long>, 2> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<long>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<long>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<long>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<long>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<long>& back() { return values[1]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<long>& back() const { return values[1]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 2; }
+
+  Eigen::IndexPair<long> values[2];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::IndexPair<long>> l) {
+    eigen_assert(l.size() == 2);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(long v0_first, long v0_second,
+        long v1_first, long v1_second) [[cpu]][[hc]] {
+    values[0] = Eigen::IndexPair<long>(v0_first, v0_second);
+    values[1] = Eigen::IndexPair<long>(v1_first, v1_second);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    s.Append(sizeof(long), &values[0].first);
+    s.Append(sizeof(long), &values[0].second);
+    s.Append(sizeof(long), &values[1].first);
+    s.Append(sizeof(long), &values[1].second);
+  }
+
+  array(Eigen::IndexPair<long> v0,
+        Eigen::IndexPair<long> v1) {
+    values[0].set(v0);
+    values[1].set(v1);
+  }
+};
+
+// Specialize array for size 2 and T = std::pair<int, int>
+template<>
+class array<std::pair<int, int>, 2> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE std::pair<int, int>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const std::pair<int, int>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE std::pair<int, int> front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const std::pair<int, int>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE std::pair<int, int>& back() { return values[1]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const std::pair<int, int>& back() const { return values[1]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 2; }
+
+  std::pair<int, int> values[2];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<std::pair<int, int> > l) {
+    eigen_assert(l.size() == 2);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(int v0_first, int v0_second,
+        int v1_first, int v1_second) [[cpu]][[hc]] {
+    values[0] = std::pair<int, int>(v0_first, v0_second);
+    values[1] = std::pair<int, int>(v1_first, v1_second);
+  }
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    s.Append(sizeof(int), &values[0].first);
+    s.Append(sizeof(int), &values[0].second);
+    s.Append(sizeof(int), &values[1].first);
+    s.Append(sizeof(int), &values[1].second);
+  }
+
+  array(std::pair<int, int> v0,
+        std::pair<int, int> v1) {
+    values[0] = v0;
+    values[1] = v1;
+  }
+};
+
+// Specialize array for size 3 and T = Eigen::IndexPair<int>
+template <>
+class array<Eigen::IndexPair<int>, 3> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<int>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<int>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<int>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<int>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<int>& back() { return values[2]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<int>& back() const { return values[2]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 3; }
+
+  Eigen::IndexPair<int> values[3];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::IndexPair<int> > l) {
+    eigen_assert(l.size() == 3);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(int v0_first, int v0_second,
+        int v1_first, int v1_second,
+        int v2_first, int v2_second) [[cpu]][[hc]] {
+    values[0] = Eigen::IndexPair<int>(v0_first, v0_second);
+    values[1] = Eigen::IndexPair<int>(v1_first, v1_second);
+    values[2] = Eigen::IndexPair<int>(v2_first, v2_second);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    for (int i = 0; i < 3; ++i) {
+      s.Append(sizeof(int), &values[i].first);
+      s.Append(sizeof(int), &values[i].second);
+    }
+  }
+
+  array(Eigen::IndexPair<int> v0,
+        Eigen::IndexPair<int> v1,
+        Eigen::IndexPair<int> v2) {
+    values[0].set(v0);
+    values[1].set(v1);
+    values[2].set(v2);
+  }
+};
+
+// Specialize array for size 3 and T = Eigen::IndexPair<long>
+template <>
+class array<Eigen::IndexPair<long>, 3> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<long>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<long>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<long>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<long>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<long>& back() { return values[2]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<long>& back() const { return values[2]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 3; }
+
+  Eigen::IndexPair<long> values[3];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::IndexPair<long> > l) {
+    eigen_assert(l.size() == 3);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(long v0_first, long v0_second,
+        long v1_first, long v1_second,
+        long v2_first, long v2_second) [[cpu]][[hc]] {
+    values[0] = Eigen::IndexPair<long>(v0_first, v0_second);
+    values[1] = Eigen::IndexPair<long>(v1_first, v1_second);
+    values[2] = Eigen::IndexPair<long>(v2_first, v2_second);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    for (int i = 0; i < 3; ++i) {
+      s.Append(sizeof(long), &values[i].first);
+      s.Append(sizeof(long), &values[i].second);
+    }
+  }
+
+  array(Eigen::IndexPair<long> v0,
+        Eigen::IndexPair<long> v1,
+        Eigen::IndexPair<long> v2) {
+    values[0].set(v0);
+    values[1].set(v1);
+    values[2].set(v2);
+  }
+};
+
+// Specialize array for size 3 and T = std::pair<int, int>
+template<>
+class array<std::pair<int, int>, 3> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE std::pair<int, int>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const std::pair<int, int>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE std::pair<int, int> front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const std::pair<int, int>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE std::pair<int, int>& back() { return values[2]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const std::pair<int, int>& back() const { return values[2]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 3; }
+
+  std::pair<int, int> values[3];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<std::pair<int, int> > l) {
+    eigen_assert(l.size() == 3);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(int v0_first, int v0_second,
+        int v1_first, int v1_second,
+        int v2_first, int v2_second) [[cpu]][[hc]] {
+    values[0] = std::pair<int, int>(v0_first, v0_second);
+    values[1] = std::pair<int, int>(v1_first, v1_second);
+    values[2] = std::pair<int, int>(v2_first, v2_second);
+  }
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    for (int i = 0; i < 3; ++i) {
+      s.Append(sizeof(int), &values[i].first);
+      s.Append(sizeof(int), &values[i].second);
+    }
+  }
+
+  array(std::pair<int, int> v0,
+        std::pair<int, int> v1,
+        std::pair<int, int> v2) {
+    values[0] = v0;
+    values[1] = v1;
+    values[2] = v2;
+  }
+};
+
+// Specialize array for size 4 and T = Eigen::IndexPair<int>
+template <>
+class array<Eigen::IndexPair<int>, 4> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<int>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<int>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<int>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<int>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<int>& back() { return values[3]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<int>& back() const { return values[3]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 4; }
+
+  Eigen::IndexPair<int> values[4];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::IndexPair<int> > l) {
+    eigen_assert(l.size() == 4);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(int v0_first, int v0_second,
+        int v1_first, int v1_second,
+        int v2_first, int v2_second,
+        int v3_first, int v3_second) [[cpu]][[hc]] {
+    values[0] = Eigen::IndexPair<int>(v0_first, v0_second);
+    values[1] = Eigen::IndexPair<int>(v1_first, v1_second);
+    values[2] = Eigen::IndexPair<int>(v2_first, v2_second);
+    values[3] = Eigen::IndexPair<int>(v3_first, v3_second);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    for (int i = 0; i < 4; ++i) {
+      s.Append(sizeof(int), &values[i].first);
+      s.Append(sizeof(int), &values[i].second);
+    }
+  }
+
+  array(Eigen::IndexPair<int> v0,
+        Eigen::IndexPair<int> v1,
+        Eigen::IndexPair<int> v2,
+        Eigen::IndexPair<int> v3) {
+    values[0].set(v0);
+    values[1].set(v1);
+    values[2].set(v2);
+    values[3].set(v3);
+  }
+};
+
+// Specialize array for size 4 and T = Eigen::IndexPair<long>
+template <>
+class array<Eigen::IndexPair<long>, 4> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<long>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<long>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<long>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<long>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<long>& back() { return values[3]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<long>& back() const { return values[3]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 4; }
+
+  Eigen::IndexPair<long> values[4];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::IndexPair<long> > l) {
+    eigen_assert(l.size() == 4);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(long v0_first, long v0_second,
+        long v1_first, long v1_second,
+        long v2_first, long v2_second,
+        long v3_first, long v3_second) [[cpu]][[hc]] {
+    values[0] = Eigen::IndexPair<long>(v0_first, v0_second);
+    values[1] = Eigen::IndexPair<long>(v1_first, v1_second);
+    values[2] = Eigen::IndexPair<long>(v2_first, v2_second);
+    values[3] = Eigen::IndexPair<long>(v3_first, v3_second);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    for (int i = 0; i < 4; ++i) {
+      s.Append(sizeof(long), &values[i].first);
+      s.Append(sizeof(long), &values[i].second);
+    }
+  }
+
+  array(Eigen::IndexPair<long> v0,
+        Eigen::IndexPair<long> v1,
+        Eigen::IndexPair<long> v2,
+        Eigen::IndexPair<long> v3) {
+    values[0].set(v0);
+    values[1].set(v1);
+    values[2].set(v2);
+    values[3].set(v3);
+  }
+};
+
+// Specialize array for size 4 and T = std::pair<int, int>
+template<>
+class array<std::pair<int, int>, 4> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE std::pair<int, int>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const std::pair<int, int>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE std::pair<int, int> front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const std::pair<int, int>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE std::pair<int, int>& back() { return values[3]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const std::pair<int, int>& back() const { return values[3]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 4; }
+
+  std::pair<int, int> values[4];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<std::pair<int, int> > l) {
+    eigen_assert(l.size() == 4);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(int v0_first, int v0_second,
+        int v1_first, int v1_second,
+        int v2_first, int v2_second,
+        int v3_first, int v3_second) [[cpu]][[hc]] {
+    values[0] = std::pair<int, int>(v0_first, v0_second);
+    values[1] = std::pair<int, int>(v1_first, v1_second);
+    values[2] = std::pair<int, int>(v2_first, v2_second);
+    values[3] = std::pair<int, int>(v3_first, v3_second);
+  }
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    for (int i = 0; i < 4; ++i) {
+      s.Append(sizeof(int), &values[i].first);
+      s.Append(sizeof(int), &values[i].second);
+    }
+  }
+
+  array(std::pair<int, int> v0,
+        std::pair<int, int> v1,
+        std::pair<int, int> v2,
+        std::pair<int, int> v3) {
+    values[0] = v0;
+    values[1] = v1;
+    values[2] = v2;
+    values[3] = v3;
+  }
+};
+
+// Specialize array for size 5 and T = Eigen::IndexPair<int>
+template <>
+class array<Eigen::IndexPair<int>, 5> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<int>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<int>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<int>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<int>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<int>& back() { return values[4]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<int>& back() const { return values[4]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 5; }
+
+  Eigen::IndexPair<int> values[5];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::IndexPair<int> > l) {
+    eigen_assert(l.size() == 5);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(int v0_first, int v0_second,
+        int v1_first, int v1_second,
+        int v2_first, int v2_second,
+        int v3_first, int v3_second,
+        int v4_first, int v4_second) [[cpu]][[hc]] {
+    values[0] = Eigen::IndexPair<int>(v0_first, v0_second);
+    values[1] = Eigen::IndexPair<int>(v1_first, v1_second);
+    values[2] = Eigen::IndexPair<int>(v2_first, v2_second);
+    values[3] = Eigen::IndexPair<int>(v3_first, v3_second);
+    values[4] = Eigen::IndexPair<int>(v4_first, v4_second);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    for (int i = 0; i < 5; ++i) {
+      s.Append(sizeof(int), &values[i].first);
+      s.Append(sizeof(int), &values[i].second);
+    }
+  }
+
+  array(Eigen::IndexPair<int> v0,
+        Eigen::IndexPair<int> v1,
+        Eigen::IndexPair<int> v2,
+        Eigen::IndexPair<int> v3,
+        Eigen::IndexPair<int> v4) {
+    values[0].set(v0);
+    values[1].set(v1);
+    values[2].set(v2);
+    values[3].set(v3);
+    values[4].set(v4);
+  }
+};
+ 
+// Specialize array for size 5 and T = Eigen::IndexPair<long>
+template <>
+class array<Eigen::IndexPair<long>, 5> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<long>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<long>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<long>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<long>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<long>& back() { return values[4]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<long>& back() const { return values[4]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 5; }
+
+  Eigen::IndexPair<long> values[5];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::IndexPair<long> > l) {
+    eigen_assert(l.size() == 5);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(long v0_first, long v0_second,
+        long v1_first, long v1_second,
+        long v2_first, long v2_second,
+        long v3_first, long v3_second,
+        long v4_first, long v4_second) [[cpu]][[hc]] {
+    values[0] = Eigen::IndexPair<long>(v0_first, v0_second);
+    values[1] = Eigen::IndexPair<long>(v1_first, v1_second);
+    values[2] = Eigen::IndexPair<long>(v2_first, v2_second);
+    values[3] = Eigen::IndexPair<long>(v3_first, v3_second);
+    values[4] = Eigen::IndexPair<long>(v4_first, v4_second);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    for (int i = 0; i < 5; ++i) {
+      s.Append(sizeof(long), &values[i].first);
+      s.Append(sizeof(long), &values[i].second);
+    }
+  }
+
+  array(Eigen::IndexPair<long> v0,
+        Eigen::IndexPair<long> v1,
+        Eigen::IndexPair<long> v2,
+        Eigen::IndexPair<long> v3,
+        Eigen::IndexPair<long> v4) {
+    values[0].set(v0);
+    values[1].set(v1);
+    values[2].set(v2);
+    values[3].set(v3);
+    values[4].set(v4);
+  }
+};
+
+// Specialize array for size 5 and T = std::pair<int, int>
+template<>
+class array<std::pair<int, int>, 5> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE std::pair<int, int>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const std::pair<int, int>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE std::pair<int, int> front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const std::pair<int, int>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE std::pair<int, int>& back() { return values[4]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const std::pair<int, int>& back() const { return values[4]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 5; }
+
+  std::pair<int, int> values[5];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<std::pair<int, int> > l) {
+    eigen_assert(l.size() == 5);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(int v0_first, int v0_second,
+        int v1_first, int v1_second,
+        int v2_first, int v2_second,
+        int v3_first, int v3_second,
+        int v4_first, int v4_second) [[cpu]][[hc]] {
+    values[0] = std::pair<int, int>(v0_first, v0_second);
+    values[1] = std::pair<int, int>(v1_first, v1_second);
+    values[2] = std::pair<int, int>(v2_first, v2_second);
+    values[3] = std::pair<int, int>(v3_first, v3_second);
+    values[4] = std::pair<int, int>(v4_first, v4_second);
+  }
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    for (int i = 0; i < 5; ++i) {
+      s.Append(sizeof(int), &values[i].first);
+      s.Append(sizeof(int), &values[i].second);
+    }
+  }
+
+  array(std::pair<int, int> v0,
+        std::pair<int, int> v1,
+        std::pair<int, int> v2,
+        std::pair<int, int> v3,
+        std::pair<int, int> v4) {
+    values[0] = v0;
+    values[1] = v1;
+    values[2] = v2;
+    values[3] = v3;
+    values[4] = v4;
+  }
+};
+
+// Specialize array for size 6 and T = Eigen::IndexPair<int>
+template <>
+class array<Eigen::IndexPair<int>, 6> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<int>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<int>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<int>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<int>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<int>& back() { return values[5]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<int>& back() const { return values[5]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 6; }
+
+  Eigen::IndexPair<int> values[6];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::IndexPair<int> > l) {
+    eigen_assert(l.size() == 6);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(int v0_first, int v0_second,
+        int v1_first, int v1_second,
+        int v2_first, int v2_second,
+        int v3_first, int v3_second,
+        int v4_first, int v4_second,
+        int v5_first, int v5_second) [[cpu]][[hc]] {
+    values[0] = Eigen::IndexPair<int>(v0_first, v0_second);
+    values[1] = Eigen::IndexPair<int>(v1_first, v1_second);
+    values[2] = Eigen::IndexPair<int>(v2_first, v2_second);
+    values[3] = Eigen::IndexPair<int>(v3_first, v3_second);
+    values[4] = Eigen::IndexPair<int>(v4_first, v4_second);
+    values[5] = Eigen::IndexPair<int>(v5_first, v5_second);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    for (int i = 0; i < 6; ++i) {
+      s.Append(sizeof(int), &values[i].first);
+      s.Append(sizeof(int), &values[i].second);
+    }
+  }
+
+  array(Eigen::IndexPair<int> v0,
+        Eigen::IndexPair<int> v1,
+        Eigen::IndexPair<int> v2,
+        Eigen::IndexPair<int> v3,
+        Eigen::IndexPair<int> v4,
+        Eigen::IndexPair<int> v5) {
+    values[0].set(v0);
+    values[1].set(v1);
+    values[2].set(v2);
+    values[3].set(v3);
+    values[4].set(v4);
+    values[5].set(v5);
+  }
+};
+
+// Specialize array for size 6 and T = Eigen::IndexPair<long>
+template <>
+class array<Eigen::IndexPair<long>, 6> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<long>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<long>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<long>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<long>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<long>& back() { return values[5]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<long>& back() const { return values[5]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 6; }
+
+  Eigen::IndexPair<long> values[6];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::IndexPair<long> > l) {
+    eigen_assert(l.size() == 6);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(long v0_first, long v0_second,
+        long v1_first, long v1_second,
+        long v2_first, long v2_second,
+        long v3_first, long v3_second,
+        long v4_first, long v4_second,
+        long v5_first, long v5_second) [[cpu]][[hc]] {
+    values[0] = Eigen::IndexPair<long>(v0_first, v0_second);
+    values[1] = Eigen::IndexPair<long>(v1_first, v1_second);
+    values[2] = Eigen::IndexPair<long>(v2_first, v2_second);
+    values[3] = Eigen::IndexPair<long>(v3_first, v3_second);
+    values[4] = Eigen::IndexPair<long>(v4_first, v4_second);
+    values[5] = Eigen::IndexPair<long>(v5_first, v5_second);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    for (int i = 0; i < 6; ++i) {
+      s.Append(sizeof(long), &values[i].first);
+      s.Append(sizeof(long), &values[i].second);
+    }
+  }
+
+  array(Eigen::IndexPair<long> v0,
+        Eigen::IndexPair<long> v1,
+        Eigen::IndexPair<long> v2,
+        Eigen::IndexPair<long> v3,
+        Eigen::IndexPair<long> v4,
+        Eigen::IndexPair<long> v5) {
+    values[0].set(v0);
+    values[1].set(v1);
+    values[2].set(v2);
+    values[3].set(v3);
+    values[4].set(v4);
+    values[5].set(v5);
+  }
+};
+
+// Specialize array for size 6 and T = std::pair<int, int>
+template<>
+class array<std::pair<int, int>, 6> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE std::pair<int, int>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const std::pair<int, int>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE std::pair<int, int> front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const std::pair<int, int>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE std::pair<int, int>& back() { return values[5]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const std::pair<int, int>& back() const { return values[5]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 6; }
+
+  std::pair<int, int> values[6];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<std::pair<int, int> > l) {
+    eigen_assert(l.size() == 6);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(int v0_first, int v0_second,
+        int v1_first, int v1_second,
+        int v2_first, int v2_second,
+        int v3_first, int v3_second,
+        int v4_first, int v4_second,
+        int v5_first, int v5_second) [[cpu]][[hc]] {
+    values[0] = std::pair<int, int>(v0_first, v0_second);
+    values[1] = std::pair<int, int>(v1_first, v1_second);
+    values[2] = std::pair<int, int>(v2_first, v2_second);
+    values[3] = std::pair<int, int>(v3_first, v3_second);
+    values[4] = std::pair<int, int>(v4_first, v4_second);
+    values[5] = std::pair<int, int>(v5_first, v5_second);
+  }
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    for (int i = 0; i < 6; ++i) {
+      s.Append(sizeof(int), &values[i].first);
+      s.Append(sizeof(int), &values[i].second);
+    }
+  }
+
+  array(std::pair<int, int> v0,
+        std::pair<int, int> v1,
+        std::pair<int, int> v2,
+        std::pair<int, int> v3,
+        std::pair<int, int> v4,
+        std::pair<int, int> v5) {
+    values[0] = v0;
+    values[1] = v1;
+    values[2] = v2;
+    values[3] = v3;
+    values[4] = v4;
+    values[5] = v5;
+  }
+};
+
+// Specialize array for size 7 and T = Eigen::IndexPair<int>
+template <>
+class array<Eigen::IndexPair<int>, 7> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<int>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<int>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<int>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<int>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<int>& back() { return values[6]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<int>& back() const { return values[6]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 7; }
+
+  Eigen::IndexPair<int> values[7];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::IndexPair<int> > l) {
+    eigen_assert(l.size() == 7);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(int v0_first, int v0_second,
+        int v1_first, int v1_second,
+        int v2_first, int v2_second,
+        int v3_first, int v3_second,
+        int v4_first, int v4_second,
+        int v5_first, int v5_second,
+        int v6_first, int v6_second) [[cpu]][[hc]] {
+    values[0] = Eigen::IndexPair<int>(v0_first, v0_second);
+    values[1] = Eigen::IndexPair<int>(v1_first, v1_second);
+    values[2] = Eigen::IndexPair<int>(v2_first, v2_second);
+    values[3] = Eigen::IndexPair<int>(v3_first, v3_second);
+    values[4] = Eigen::IndexPair<int>(v4_first, v4_second);
+    values[5] = Eigen::IndexPair<int>(v5_first, v5_second);
+    values[6] = Eigen::IndexPair<int>(v6_first, v6_second);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    for (int i = 0; i < 7; ++i) {
+      s.Append(sizeof(int), &values[i].first);
+      s.Append(sizeof(int), &values[i].second);
+    }
+  }
+
+  array(Eigen::IndexPair<int> v0,
+        Eigen::IndexPair<int> v1,
+        Eigen::IndexPair<int> v2,
+        Eigen::IndexPair<int> v3,
+        Eigen::IndexPair<int> v4,
+        Eigen::IndexPair<int> v5,
+        Eigen::IndexPair<int> v6) {
+    values[0].set(v0);
+    values[1].set(v1);
+    values[2].set(v2);
+    values[3].set(v3);
+    values[4].set(v4);
+    values[5].set(v5);
+    values[6].set(v6);
+  }
+};
+ 
+// Specialize array for size 7 and T = Eigen::IndexPair<long>
+template <>
+class array<Eigen::IndexPair<long>, 7> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<long>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<long>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<long>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<long>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<long>& back() { return values[6]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<long>& back() const { return values[6]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 7; }
+
+  Eigen::IndexPair<long> values[7];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::IndexPair<long> > l) {
+    eigen_assert(l.size() == 7);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(long v0_first, long v0_second,
+        long v1_first, long v1_second,
+        long v2_first, long v2_second,
+        long v3_first, long v3_second,
+        long v4_first, long v4_second,
+        long v5_first, long v5_second,
+        long v6_first, long v6_second) [[cpu]][[hc]] {
+    values[0] = Eigen::IndexPair<long>(v0_first, v0_second);
+    values[1] = Eigen::IndexPair<long>(v1_first, v1_second);
+    values[2] = Eigen::IndexPair<long>(v2_first, v2_second);
+    values[3] = Eigen::IndexPair<long>(v3_first, v3_second);
+    values[4] = Eigen::IndexPair<long>(v4_first, v4_second);
+    values[5] = Eigen::IndexPair<long>(v5_first, v5_second);
+    values[6] = Eigen::IndexPair<long>(v6_first, v6_second);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    for (int i = 0; i < 7; ++i) {
+      s.Append(sizeof(long), &values[i].first);
+      s.Append(sizeof(long), &values[i].second);
+    }
+  }
+
+  array(Eigen::IndexPair<long> v0,
+        Eigen::IndexPair<long> v1,
+        Eigen::IndexPair<long> v2,
+        Eigen::IndexPair<long> v3,
+        Eigen::IndexPair<long> v4,
+        Eigen::IndexPair<long> v5,
+        Eigen::IndexPair<long> v6) {
+    values[0].set(v0);
+    values[1].set(v1);
+    values[2].set(v2);
+    values[3].set(v3);
+    values[4].set(v4);
+    values[5].set(v5);
+    values[6].set(v6);
+  }
+};
+
+// Specialize array for size 7 and T = std::pair<int, int>
+template<>
+class array<std::pair<int, int>, 7> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE std::pair<int, int>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const std::pair<int, int>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE std::pair<int, int> front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const std::pair<int, int>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE std::pair<int, int>& back() { return values[6]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const std::pair<int, int>& back() const { return values[6]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 7; }
+
+  std::pair<int, int> values[7];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<std::pair<int, int> > l) {
+    eigen_assert(l.size() == 7);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(int v0_first, int v0_second,
+        int v1_first, int v1_second,
+        int v2_first, int v2_second,
+        int v3_first, int v3_second,
+        int v4_first, int v4_second,
+        int v5_first, int v5_second,
+        int v6_first, int v6_second) [[cpu]][[hc]] {
+    values[0] = std::pair<int, int>(v0_first, v0_second);
+    values[1] = std::pair<int, int>(v1_first, v1_second);
+    values[2] = std::pair<int, int>(v2_first, v2_second);
+    values[3] = std::pair<int, int>(v3_first, v3_second);
+    values[4] = std::pair<int, int>(v4_first, v4_second);
+    values[5] = std::pair<int, int>(v5_first, v5_second);
+    values[6] = std::pair<int, int>(v6_first, v6_second);
+  }
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    for (int i = 0; i < 7; ++i) {
+      s.Append(sizeof(int), &values[i].first);
+      s.Append(sizeof(int), &values[i].second);
+    }
+  }
+
+  array(std::pair<int, int> v0,
+        std::pair<int, int> v1,
+        std::pair<int, int> v2,
+        std::pair<int, int> v3,
+        std::pair<int, int> v4,
+        std::pair<int, int> v5,
+        std::pair<int, int> v6) {
+    values[0] = v0;
+    values[1] = v1;
+    values[2] = v2;
+    values[3] = v3;
+    values[4] = v4;
+    values[5] = v5;
+    values[6] = v6;
+  }
+};
+
+// Specialize array for size 8 and T = Eigen::IndexPair<int>
+template <>
+class array<Eigen::IndexPair<int>, 8> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<int>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<int>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<int>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<int>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<int>& back() { return values[7]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<int>& back() const { return values[7]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 8; }
+
+  Eigen::IndexPair<int> values[8];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::IndexPair<int> > l) {
+    eigen_assert(l.size() == 8);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(int v0_first, int v0_second,
+        int v1_first, int v1_second,
+        int v2_first, int v2_second,
+        int v3_first, int v3_second,
+        int v4_first, int v4_second,
+        int v5_first, int v5_second,
+        int v6_first, int v6_second,
+        int v7_first, int v7_second) [[cpu]][[hc]] {
+    values[0] = Eigen::IndexPair<int>(v0_first, v0_second);
+    values[1] = Eigen::IndexPair<int>(v1_first, v1_second);
+    values[2] = Eigen::IndexPair<int>(v2_first, v2_second);
+    values[3] = Eigen::IndexPair<int>(v3_first, v3_second);
+    values[4] = Eigen::IndexPair<int>(v4_first, v4_second);
+    values[5] = Eigen::IndexPair<int>(v5_first, v5_second);
+    values[6] = Eigen::IndexPair<int>(v6_first, v6_second);
+    values[7] = Eigen::IndexPair<int>(v7_first, v7_second);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    for (int i = 0; i < 8; ++i) {
+      s.Append(sizeof(int), &values[i].first);
+      s.Append(sizeof(int), &values[i].second);
+    }
+  }
+
+  array(Eigen::IndexPair<int> v0,
+        Eigen::IndexPair<int> v1,
+        Eigen::IndexPair<int> v2,
+        Eigen::IndexPair<int> v3,
+        Eigen::IndexPair<int> v4,
+        Eigen::IndexPair<int> v5,
+        Eigen::IndexPair<int> v6,
+        Eigen::IndexPair<int> v7) {
+    values[0].set(v0);
+    values[1].set(v1);
+    values[2].set(v2);
+    values[3].set(v3);
+    values[4].set(v4);
+    values[5].set(v5);
+    values[6].set(v6);
+    values[7].set(v7);
+  }
+};
+
+// Specialize array for size 8 and T = Eigen::IndexPair<long>
+template <>
+class array<Eigen::IndexPair<long>, 8> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<long>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<long>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<long>& front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<long>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE Eigen::IndexPair<long>& back() { return values[7]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const Eigen::IndexPair<long>& back() const { return values[7]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 8; }
+
+  Eigen::IndexPair<long> values[8];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<Eigen::IndexPair<long> > l) {
+    eigen_assert(l.size() == 8);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(long v0_first, long v0_second,
+        long v1_first, long v1_second,
+        long v2_first, long v2_second,
+        long v3_first, long v3_second,
+        long v4_first, long v4_second,
+        long v5_first, long v5_second,
+        long v6_first, long v6_second,
+        long v7_first, long v7_second) [[cpu]][[hc]] {
+    values[0] = Eigen::IndexPair<long>(v0_first, v0_second);
+    values[1] = Eigen::IndexPair<long>(v1_first, v1_second);
+    values[2] = Eigen::IndexPair<long>(v2_first, v2_second);
+    values[3] = Eigen::IndexPair<long>(v3_first, v3_second);
+    values[4] = Eigen::IndexPair<long>(v4_first, v4_second);
+    values[5] = Eigen::IndexPair<long>(v5_first, v5_second);
+    values[6] = Eigen::IndexPair<long>(v6_first, v6_second);
+    values[7] = Eigen::IndexPair<long>(v7_first, v7_second);
+  }
+
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    for (int i = 0; i < 8; ++i) {
+      s.Append(sizeof(long), &values[i].first);
+      s.Append(sizeof(long), &values[i].second);
+    }
+  }
+
+  array(Eigen::IndexPair<long> v0,
+        Eigen::IndexPair<long> v1,
+        Eigen::IndexPair<long> v2,
+        Eigen::IndexPair<long> v3,
+        Eigen::IndexPair<long> v4,
+        Eigen::IndexPair<long> v5,
+        Eigen::IndexPair<long> v6,
+        Eigen::IndexPair<long> v7) {
+    values[0].set(v0);
+    values[1].set(v1);
+    values[2].set(v2);
+    values[3].set(v3);
+    values[4].set(v4);
+    values[5].set(v5);
+    values[6].set(v6);
+    values[7].set(v7);
+  }
+};
+
+// Specialize array for size 8 and T = std::pair<int, int>
+template<>
+class array<std::pair<int, int>, 8> {
+ public:
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE std::pair<int, int>& operator[] (size_t index) { return values[index]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const std::pair<int, int>& operator[] (size_t index) const { return values[index]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE std::pair<int, int> front() { return values[0]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const std::pair<int, int>& front() const { return values[0]; }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE std::pair<int, int>& back() { return values[7]; }
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE const std::pair<int, int>& back() const { return values[7]; }
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE
+  static std::size_t size() { return 8; }
+
+  std::pair<int, int> values[8];
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array() { }
+
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE ~array() { }
+
+#if EIGEN_HAS_VARIADIC_TEMPLATES
+  EIGEN_DEVICE_FUNC
+  EIGEN_STRONG_INLINE array(std::initializer_list<std::pair<int, int> > l) {
+    eigen_assert(l.size() == 8);
+    internal::smart_copy(l.begin(), l.end(), values);
+  }
+#endif
+
+  __attribute__((annotate("user_deserialize")))
+  array(int v0_first, int v0_second,
+        int v1_first, int v1_second,
+        int v2_first, int v2_second,
+        int v3_first, int v3_second,
+        int v4_first, int v4_second,
+        int v5_first, int v5_second,
+        int v6_first, int v6_second,
+        int v7_first, int v7_second) [[cpu]][[hc]] {
+    values[0] = std::pair<int, int>(v0_first, v0_second);
+    values[1] = std::pair<int, int>(v1_first, v1_second);
+    values[2] = std::pair<int, int>(v2_first, v2_second);
+    values[3] = std::pair<int, int>(v3_first, v3_second);
+    values[4] = std::pair<int, int>(v4_first, v4_second);
+    values[5] = std::pair<int, int>(v5_first, v5_second);
+    values[6] = std::pair<int, int>(v6_first, v6_second);
+    values[7] = std::pair<int, int>(v7_first, v7_second);
+  }
+  __attribute__((annotate("serialize")))
+  void __cxxamp_serialize(Kalmar::Serialize &s) const {
+    for (int i = 0; i < 8; ++i) {
+      s.Append(sizeof(int), &values[i].first);
+      s.Append(sizeof(int), &values[i].second);
+    }
+  }
+
+  array(std::pair<int, int> v0,
+        std::pair<int, int> v1,
+        std::pair<int, int> v2,
+        std::pair<int, int> v3,
+        std::pair<int, int> v4,
+        std::pair<int, int> v5,
+        std::pair<int, int> v6,
+        std::pair<int, int> v7) {
+    values[0] = v0;
+    values[1] = v1;
+    values[2] = v2;
+    values[3] = v3;
+    values[4] = v4;
+    values[5] = v5;
+    values[6] = v6;
+    values[7] = v7;
+  }
+};
+
+#endif // #ifdef __HCC__
 
 
 #ifdef EIGEN_HAS_SFINAE


### PR DESCRIPTION
Add custom serializers and deserializers for Eigen::array when elements are:

- Eigen::interal::TensorIntDivisor
- Eigen::IndexPair
- std::pair

This helps create correct kernels for hipeigen-based applications, such as
hiptensorflow.

hipeigen `make check` result:

```
100% tests passed, 0 tests failed out of 127
```